### PR TITLE
Create envire types for the visuals and collisions when loading yaml scene

### DIFF
--- a/src/MarsSceneLoader.cpp
+++ b/src/MarsSceneLoader.cpp
@@ -44,6 +44,7 @@ namespace mars
         using namespace utils;
         using namespace interfaces;
         using namespace configmaps;
+        using namespace envire::smurf_loader;
 
         MarsSceneLoader::MarsSceneLoader(lib_manager::LibManager *theManager) :
             interfaces::LoadSceneInterface{theManager}
@@ -378,7 +379,7 @@ namespace mars
                 configmaps::ConfigMap worldMap;
                 worldMap["name"] = worldFrame;
                 worldMap["prefix"] = config["name"].getString();
-                std::string worldClassName(BASE_TYPES_NAMESPACE + std::string("World"));
+                std::string worldClassName(base_types_namespace + std::string("World"));
                 envire::core::ItemBase::Ptr worldItem = envire::types::TypeCreatorFactory::createItem(worldClassName, worldMap);
                 ControlCenter::envireGraph->addItemToFrame(worldFrame, worldItem);
 
@@ -432,7 +433,7 @@ namespace mars
                 }
 
                 // create and add into the graph envire item with the object corresponding to config type
-                std::string visualClassName(GEOMETRY_NAMESPACE + config["type"].toString());
+                std::string visualClassName(geometry_namespace + config["type"].toString());
                 envire::core::ItemBase::Ptr visualItem = envire::types::TypeCreatorFactory::createItem(visualClassName, config);
                 if (!visualItem) {
                     LOG_ERROR_S << "Can not add visual " << config["name"].toString()
@@ -477,7 +478,7 @@ namespace mars
                         ControlCenter::envireGraph->addTransform(worldFrame, collisionFrame, initPose);
 
                         // create and add into the graph envire item with the object corresponding to config type
-                        std::string collisionClassName(GEOMETRY_NAMESPACE + config["type"].toString());
+                        std::string collisionClassName(geometry_namespace + config["type"].toString());
                         envire::core::ItemBase::Ptr colisionItem = envire::types::TypeCreatorFactory::createItem(collisionClassName, config);
                         if (!colisionItem) {
                             LOG_ERROR_S << "Can not add collision " << config["name"].toString()


### PR DESCRIPTION
Hello,

some changes which avoid direct loading of visuals in the graphics and collisions. Now, respective envire types are created when loading the YAML scene. I had to create a new world child for each node in the nodeList so that they can be positioned independent of each other. Tested this on the crex/crex_sim scene which also uses the plane.yaml.

These merge changes are related to the other pull requests in graphcs and collision library because I need to add the Plane object also as a subscriber to the the EnvireGraph events.

Below is the list of objects which are tested. Checked are the one which I have tested. I will test the others as well. Please do not merge until all are tested.

- [x] Plane
- [x] Box
- [x] Sphere
- [x] Capsule
- [x] Mesh
- [x] Cylinder
- [x] Terrain

Pr-requisites:

- [x] https://github.com/mars-robot-simulation/envire_mars_graphics/pull/1
- [x] https://github.com/mars-robot-simulation/envire_mars_ode_collision/pull/1
- [x] https://github.com/envire/envire-envire_smurf_loader/pull/1
- [x] https://github.com/mars-robot-simulation/mars_interfaces/pull/4
- [x] https://github.com/envire/envire-envire_types/pull/1
- [x] https://github.com/mars-robot-simulation/mars_scene_loader/pull/2
- [x] The materials of the objects are somehow not visualized
- [x] https://github.com/mars-robot-simulation/environment-mars/pull/1


Best,
Haider