### PR TITLE
Fix the node pose relative to the local world

### DIFF
--- a/src/MarsSceneLoader.cpp
+++ b/src/MarsSceneLoader.cpp
@@ -350,8 +350,6 @@ namespace mars
 
                 interfaces::NodeData nodeData;
                 nodeData.fromConfigMap(&config, "");
-                nodeData.pos += pos;
-                nodeData.rot *= rot;
                 envire::core::Transform framePose(nodeData.pos, nodeData.rot);
           
                 std::string objectType = "";


### PR DESCRIPTION
@jliersch 

this small change fixes the pose of nodes loaded from a yaml. The position of the yaml file was summed up twice. Once when creating the local yaml world and once again when loading a node relative to the local world.

Best regads,
Haider